### PR TITLE
fix rerun-if-changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 fn main() {
     // Rebuild if i18n files change
-    println!("cargo:rerun-if-changed=i18n/*/cosmic_edit.ftl")
+    println!("cargo:rerun-if-changed=i18n")
 }


### PR DESCRIPTION
I don't think `rerun-if-changed` currently support wildcard, the line triggered the build every time on my laptop