### PR TITLE
Fixed **many** Clippy lints, and one bug.

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -33,20 +33,20 @@ macro_rules! menu_button {
 }
 
 pub fn context_menu<'a>(config: &Config, entity: segmented_button::Entity) -> Element<'a, Message> {
-    let menu_item = |label, action| {
+    let menu_item = |menu_label, menu_action| {
         let mut key = String::new();
-        for (key_bind, action) in config.keybinds.iter() {
-            if action == action {
+        for (key_bind, key_action) in config.keybinds.iter() {
+            if key_action == &menu_action {
                 key = key_bind.to_string();
                 break;
             }
         }
         menu_button!(
-            widget::text(label),
+            widget::text(menu_label),
             horizontal_space(Length::Fill),
             widget::text(key)
         )
-        .on_press(Message::TabContextAction(entity, action))
+        .on_press(Message::TabContextAction(entity, menu_action))
     };
 
     widget::container(column!(

--- a/src/project.rs
+++ b/src/project.rs
@@ -76,15 +76,17 @@ impl Ord for ProjectNode {
     fn cmp(&self, other: &Self) -> Ordering {
         match self {
             // Folders are always before files
-            Self::Folder { .. } => match other {
-                Self::File { .. } => return Ordering::Less,
-                _ => {}
-            },
+            Self::Folder { .. } => {
+                if let Self::File { .. } = other {
+                    return Ordering::Less;
+                }
+            }
             // Files are always after folders
-            Self::File { .. } => match other {
-                Self::Folder { .. } => return Ordering::Greater,
-                _ => {}
-            },
+            Self::File { .. } => {
+                if let Self::Folder { .. } = other {
+                    return Ordering::Greater;
+                }
+            }
         }
         self.name().cmp(other.name())
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,13 +54,10 @@ impl ProjectSearchResult {
                             }
                         };
 
-                        match entry.file_type() {
-                            Some(file_type) => {
-                                if file_type.is_dir() {
-                                    continue;
-                                }
+                        if let Some(file_type) = entry.file_type() {
+                            if file_type.is_dir() {
+                                continue;
                             }
-                            None => {}
                         }
 
                         let entry_path = entry.path();
@@ -68,7 +65,7 @@ impl ProjectSearchResult {
                         let mut lines = Vec::new();
                         match searcher.search_path(
                             &matcher,
-                            &entry_path,
+                            entry_path,
                             UTF8(|number_u64, text| {
                                 match usize::try_from(number_u64) {
                                     Ok(number) => match matcher.find(text.as_bytes()) {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -161,7 +161,7 @@ impl EditorTab {
     pub fn watch(&self, watcher_opt: &mut Option<notify::RecommendedWatcher>) {
         if let Some(path) = &self.path_opt {
             if let Some(watcher) = watcher_opt {
-                match watcher.watch(&path, notify::RecursiveMode::NonRecursive) {
+                match watcher.watch(path, notify::RecursiveMode::NonRecursive) {
                     Ok(()) => {
                         log::info!("watching {:?} for changes", path);
                     }

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -108,16 +108,16 @@ struct Offset {
     y: i32,
 }
 
-/// This function is called Window.x * Window.y number of times
-/// each time the text is scrolled or the window is resized.
-/// If the window is moved, it's not called as the pixel buffer
+/// This function is called canvas.x * canvas.y number of times
+/// each time the text is scrolled or the canvas is resized.
+/// If the canvas is moved, it's not called as the pixel buffer
 /// is the same, it's just translated for the screen's x, y.
-/// Window is the location of the pixel in the window.
-/// Screen is the location of the pixel on the screen itself.
+/// canvas is the location of the pixel in the canvas.
+/// Screen is the location of the pixel on the screen.
 // TODO: improve performance
 fn draw_rect(
     buffer: &mut [u32],
-    window: Canvas,
+    canvas: Canvas,
     offset: Canvas,
     screen: Offset,
     cosmic_color: cosmic_text::Color,
@@ -132,9 +132,9 @@ fn draw_rect(
     let alpha = (color >> 24) & 0xFF;
 
     log::debug!(
-        "Window: {{w: {}, h: {}}}; Offset: {{w: {}, h: {}}}; Screen: {{x: {}, y: {}}}; Alpha {:#}",
-        window.w,
-        window.h,
+        "Canvas: {{w: {}, h: {}}}; Offset: {{w: {}, h: {}}}; Screen: {{x: {}, y: {}}}; Alpha {:#}",
+        canvas.w,
+        canvas.h,
         offset.w,
         offset.h,
         screen.x,
@@ -149,18 +149,18 @@ fn draw_rect(
         255 => {
             // Handle overwrite
             for x in screen.x..screen.x + offset.w {
-                if x < 0 || x >= window.w {
+                if x < 0 || x >= canvas.w {
                     // Skip if y out of bounds
                     continue;
                 }
 
                 for y in screen.y..screen.y + offset.h {
-                    if y < 0 || y >= window.h {
+                    if y < 0 || y >= canvas.h {
                         // Skip if x out of bounds
                         continue;
                     }
 
-                    let line_offset = y as usize * window.w as usize;
+                    let line_offset = y as usize * canvas.w as usize;
                     let offset = line_offset + x as usize;
                     buffer[offset] = color;
                 }
@@ -169,14 +169,14 @@ fn draw_rect(
         _ => {
             let n_alpha = 255 - alpha;
             for y in screen.y..screen.y + offset.h {
-                if y < 0 || y >= window.h {
+                if y < 0 || y >= canvas.h {
                     // Skip if y out of bounds
                     continue;
                 }
 
-                let line_offset = y as usize * window.w as usize;
+                let line_offset = y as usize * canvas.w as usize;
                 for x in screen.x..screen.x + offset.w {
-                    if x < 0 || x >= window.w {
+                    if x < 0 || x >= canvas.w {
                         // Skip if x out of bounds
                         continue;
                     }

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -119,7 +119,6 @@ fn draw_rect(
     let alpha = (color >> 24) & 0xFF;
     if alpha == 0 {
         // Do not draw if alpha is zero
-        return;
     } else if alpha >= 255 {
         // Handle overwrite
         for y in start_y..start_y + h {
@@ -172,7 +171,7 @@ fn draw_rect(
     }
 }
 
-impl<'a, 'editor, Message, Renderer> Widget<Message, Renderer> for TextBox<'a, Message>
+impl<'a, Message, Renderer> Widget<Message, Renderer> for TextBox<'a, Message>
 where
     Message: Clone,
     Renderer: renderer::Renderer + image::Renderer<Handle = image::Handle>,
@@ -233,9 +232,8 @@ where
     ) -> mouse::Interaction {
         let state = tree.state.downcast_ref::<State>();
 
-        match &state.dragging {
-            Some(Dragging::Scrollbar { .. }) => return mouse::Interaction::Idle,
-            _ => {}
+        if let Some(Dragging::Scrollbar { .. }) = &state.dragging {
+            return mouse::Interaction::Idle;
         }
 
         if let Some(p) = cursor_position.position_in(layout.bounds()) {
@@ -507,10 +505,9 @@ where
             ));
         }
 
-        let image_position =
-            layout.position() + [self.padding.left as f32, self.padding.top as f32].into();
+        let image_position = layout.position() + [self.padding.left, self.padding.top].into();
         if let Some(ref handle) = *handle_opt {
-            let image_size = image::Renderer::dimensions(renderer, &handle);
+            let image_size = image::Renderer::dimensions(renderer, handle);
             image::Renderer::draw(
                 renderer,
                 handle.clone(),
@@ -761,7 +758,7 @@ where
             Event::Mouse(MouseEvent::WheelScrolled { delta }) => {
                 if let Some(_p) = cursor_position.position_in(layout.bounds()) {
                     match delta {
-                        ScrollDelta::Lines { x, y } => {
+                        ScrollDelta::Lines { x: _, y } => {
                             //TODO: this adjustment is just a guess!
                             state.scroll_pixels = 0.0;
                             let lines = (-y * 6.0) as i32;
@@ -770,7 +767,7 @@ where
                             }
                             status = Status::Captured;
                         }
-                        ScrollDelta::Pixels { x, y } => {
+                        ScrollDelta::Pixels { x: _, y } => {
                             //TODO: this adjustment is just a guess!
                             state.scroll_pixels -= y * 6.0;
                             let mut lines = 0;
@@ -804,7 +801,7 @@ where
     }
 }
 
-impl<'a, 'editor, Message, Renderer> From<TextBox<'a, Message>> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<TextBox<'a, Message>> for Element<'a, Message, Renderer>
 where
     Message: Clone + 'a,
     Renderer: renderer::Renderer + image::Renderer<Handle = image::Handle>,


### PR DESCRIPTION
This is mostly a Clippy lint fix. A fair number of using match statements for a single value that were converted to `if let Some()`; A few areas where the `format!` macro was used for naked strings where Clippy wants `.to_string()` used; And one lifetime that was no longer used.

The only bug fix that comes in here was with the menu where menu_action and key_action were not named distinctly and so always took the branch as they were identical values being compared.

Answers #78 