### PR TITLE
[WIP] Saving Modified Files on Close

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1423,6 +1423,7 @@ impl Application for App {
                 self.project_search_value = value;
             }
             Message::Quit => {
+                // Only runs when called from the File->Quit menu item.
                 // Compile a list (VECtor) of modified tabs.
                 let mut modified = Vec::new();
                 for entity in self.tab_model.iter() {
@@ -1438,6 +1439,7 @@ impl Application for App {
                 for entity in modified {
                     self.tab_model.activate(entity);
                     let _ = self.update(Message::TabClose(self.tab_model.active()));
+                    let _ = self.update(Message::Save);
                 }
 
                 return window::close(window::Id::MAIN);

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -38,6 +38,7 @@ pub struct EditorTab {
     attrs: Attrs<'static>,
     pub editor: Mutex<ViEditor<'static, 'static>>,
     pub context_menu: Option<Point>,
+    pub modified: bool,
 }
 
 impl EditorTab {
@@ -61,6 +62,7 @@ impl EditorTab {
             attrs,
             editor: Mutex::new(ViEditor::new(editor)),
             context_menu: None,
+            modified: false,
         };
 
         // Update any other config settings
@@ -175,6 +177,7 @@ impl EditorTab {
 
     pub fn changed(&self) -> bool {
         let editor = self.editor.lock().unwrap();
+        log::warn!("changed");
         editor.changed()
     }
 


### PR DESCRIPTION
Answers #60. Added a `modified` field to the `EditorTab` struct. Currently banging my head against .iter() function for `self.tab_model.iter()` as it borrows self is immutable and I need to be able to use `EditorTab.save()` that requires a mut refrence. Currently .iter_mut() is not implemented for [`impl<SelectionMode: Default> Model<SelectionMode>`](https://github.com/pop-os/libcosmic/blob/master/src/widget/segmented_button/model/mod.rs#L295) in `libcosmic` so this is a WIP.