### PR TITLE
Add Japanese translation and update Spanish and Italian ones

### DIFF
--- a/i18n/es/cosmic_edit.ftl
+++ b/i18n/es/cosmic_edit.ftl
@@ -1,5 +1,6 @@
 new-document = Nuevo documento
 open-project = Abrir proyecto
+todo = TODO
 
 # Context Pages
 
@@ -10,12 +11,25 @@ character-count = Letras
 character-count-no-spaces = Letras (sin espacios)
 line-count = Líneas
 
+## Git management
+git-management = Gestión de Git
+unstaged-changes = Cambios no confirmados
+staged-changes = Cambios confirmados
+
+## Project search
+project-search = Búsqueda del proyecto
+
 ## Settings
 settings = Ajustes 
 
 ## Appearance
 appearance = Apariencia
 theme = Tema
+match-desktop = Sincronizar al escritorio
+dark = Oscuro
+light = Claro
+syntax-dark = Sintaxis oscura
+syntax-light = Sintaxis clara
 default-font = Tipo de letra por defecto
 default-font-size = Tamaño de letra por defecto
 
@@ -31,13 +45,17 @@ new-file = Nuevo archivo
 new-window = Nueva ventana
 open-file = Abrir archivo...
 open-recent = Abrir reciente
-todo = TODO
+close-file = Cerrar archivo
+menu-open-project = Abrir proyecto...
+open-recent-project = Abrir proyecto reciente
+close-project = Cerrar proyecto
 save = Guardar
 save-as = Guardar como...
 revert-all-changes = Deshacer todos los cambios
 menu-document-statistics = Estadísticas del documento...
 document-type = Tipo del documento...
 encoding = Codificación...
+menu-git-management = Gestión de Git...
 print = Imprimir 
 quit = Salir
 
@@ -50,7 +68,8 @@ copy = Copiar
 paste = Pegar
 find = Buscar
 replace = Reemplazar
-spell-check = Corrector ortográfico
+find-in-project = Buscar en el proyecto...
+spell-check = Corrector ortográfico...
 
 ## View
 view = Vista

--- a/i18n/it/cosmic_edit.ftl
+++ b/i18n/it/cosmic_edit.ftl
@@ -11,6 +11,14 @@ character-count = Caratteri
 character-count-no-spaces = Caratteri (senza spazi)
 line-count = Linee
 
+## Git management
+git-management = Gestione Git
+unstaged-changes = Modifiche a non committare
+staged-changes = Modifiche a committare
+
+## Project search
+project-search = Project search
+
 ## Settings
 settings = Impostazioni
 
@@ -47,6 +55,7 @@ revert-all-changes = Annulla tutte le modifiche
 menu-document-statistics = Statistiche documento...
 document-type = Tipo documento...
 encoding = Codifica...
+menu-git-management = Gestione Git...
 print = Stampa
 quit = Esci
 
@@ -60,6 +69,7 @@ paste = Incolla
 select-all = Seleziona tutto
 find = Trova
 replace = Sostituisci
+find-in-project = Trova in proggetto...
 spell-check = Controllo ortografico...
 
 ## View

--- a/i18n/it/cosmic_edit.ftl
+++ b/i18n/it/cosmic_edit.ftl
@@ -13,8 +13,8 @@ line-count = Linee
 
 ## Git management
 git-management = Gestione Git
-unstaged-changes = Modifiche a non committare
-staged-changes = Modifiche a committare
+unstaged-changes = Modifiche non confirmate
+staged-changes = Modifiche confirmate
 
 ## Project search
 project-search = Project search

--- a/i18n/ja/cosmic_edit.ftl
+++ b/i18n/ja/cosmic_edit.ftl
@@ -13,8 +13,8 @@ line-count = 行数
 
 ## Git management
 git-management = Gitの操作
-unstaged-changes = ステージされていない変更
-staged-changes = ステージされている変更
+unstaged-changes = コミットされない変更
+staged-changes = コミットされる変更
 
 ## Project search
 project-search = Project search

--- a/i18n/ja/cosmic_edit.ftl
+++ b/i18n/ja/cosmic_edit.ftl
@@ -1,0 +1,91 @@
+new-document = 新しいドキュメント
+open-project = プロジェクトを開く...
+todo = 未完
+
+# Context Pages
+
+## Document statistics
+document-statistics = Document statistics
+word-count = 単語数
+character-count = 文字数
+character-count-no-spaces = 文字数（スペース以外）
+line-count = 行数
+
+## Git management
+git-management = Gitの操作
+unstaged-changes = ステージされていない変更
+staged-changes = ステージされている変更
+
+## Project search
+project-search = Project search
+
+## Settings
+settings = 設定
+
+### Appearance
+appearance = 外観
+theme = テーマ
+match-desktop = デスクトップに合わす
+dark = 暗い
+light = 明かり
+syntax-dark = 暗いシンタックス
+syntax-light = 明かりシンタックス
+default-font = デフォルトのフォント
+default-font-size = デフォルトのフォントサイズ
+
+### Keyboard shortcuts
+keyboard-shortcuts = キーボードショートカット
+enable-vim-bindings = Vimのショートカットを有効にする
+
+# Menu
+
+## File
+file = ファイル
+new-file = 新しいファイル
+new-window = 新しいウィンドウ
+open-file = 開く...
+open-recent-file = 最近開いたファイルを開く
+close-file = ファイルを閉じる
+menu-open-project = プロジェクトを開く...
+open-recent-project = 最近開いたプロジェクトを開く
+close-project = プロジェクトを閉じる
+save = 保存
+save-as = 名前を付けて保存...
+revert-all-changes = 変更を全て元に戻す
+menu-document-statistics = Document statistics...
+document-type = Document type...
+encoding = 文字コード...
+menu-git-management = Gitの操作...
+print = 印刷
+quit = 終了
+
+## Edit
+edit = Edit
+undo = 元に戻す
+redo = やり直す
+cut = 切り取り
+copy = コピー
+paste = 貼り付け
+select-all = すべて選択
+find = 検索
+replace = 置換
+find-in-project = プロジェクトで検索...
+spell-check = スペルチェック...
+
+## View
+view = View
+indentation = Indentation
+
+### Indentation
+automatic-indentation = 自動的な字下げ
+tab-width = タブ幅: {$tab_width}
+convert-indentation-to-spaces = 字下げをスペース化
+convert-indentation-to-tabs = 字下げをタブ化
+
+word-wrap = ワードラップ
+show-line-numbers = 行番号を表示する
+highlight-current-line = 現代の行をハイライト
+syntax-highlighting = シンタックスハイライト...
+menu-settings = 設定...
+menu-keyboard-shortcuts = キーボードショートカット...
+about-cosmic-text-editor = COSMICテキストデータについて...


### PR DESCRIPTION
I have added a Japanese translation in the i18n folder as well as updated the Spanish and Italian translations, which were lacking translations for the Git management. (I also learned the hard way how difficult Git terminology is to translate.)