### PR TITLE
Update unsaved indicator on undo/redo/replace/paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.11.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#b08676909f882f553ab574601b35b58276a52458"
+source = "git+https://github.com/pop-os/cosmic-text.git#ff5501d9a36e51c50d908413caf7632d8f7533b7"
 dependencies = [
  "bitflags 2.4.2",
  "cosmic_undo_2",

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -152,7 +152,7 @@ impl EditorTab {
             });
             match fs::write(path, text) {
                 Ok(()) => {
-                    editor.set_changed(false);
+                    editor.save_point();
                     log::info!("saved {:?}", path);
                 }
                 Err(err) => {


### PR DESCRIPTION
Fixes: #116

The issue above is only about undo and redo, but I also found a few other instances where the unsaved indicator wasn't correctly updated. I fixed those as well.