### PR TITLE
Text button for Cancel in unsaved changes dialog

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1466,7 +1466,7 @@ impl Application for App {
                     widget::button::suggested(fl!("save")).on_press(Message::Save(Some(*entity)));
                 let discard_button = widget::button::destructive(fl!("discard"))
                     .on_press(Message::TabCloseForce(*entity));
-                let cancel_button = 
+                let cancel_button =
                     widget::button::text(fl!("cancel")).on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
@@ -1508,7 +1508,7 @@ impl Application for App {
                 }
                 let discard_button =
                     widget::button::destructive(fl!("discard")).on_press(Message::QuitForce);
-                let cancel_button = 
+                let cancel_button =
                     widget::button::text(fl!("cancel")).on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1467,7 +1467,7 @@ impl Application for App {
                 let discard_button = widget::button::destructive(fl!("discard"))
                     .on_press(Message::TabCloseForce(*entity));
                 let cancel_button =
-                    widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel);
+                    widget::button::standard(fl!("cancel")).style(theme::Button::Link).on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
                     .icon(icon::from_name("dialog-warning-symbolic").size(64))
@@ -1509,7 +1509,7 @@ impl Application for App {
                 let discard_button =
                     widget::button::destructive(fl!("discard")).on_press(Message::QuitForce);
                 let cancel_button =
-                    widget::button::standard(fl!("cancel")).on_press(Message::DialogCancel);
+                    widget::button::standard(fl!("cancel")).style(theme::Button::Link).on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
                     .icon(icon::from_name("dialog-warning-symbolic").size(64))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1466,9 +1466,8 @@ impl Application for App {
                     widget::button::suggested(fl!("save")).on_press(Message::Save(Some(*entity)));
                 let discard_button = widget::button::destructive(fl!("discard"))
                     .on_press(Message::TabCloseForce(*entity));
-                let cancel_button = widget::button::standard(fl!("cancel"))
-                    .style(theme::Button::Link)
-                    .on_press(Message::DialogCancel);
+                let cancel_button = 
+                    widget::button::text(fl!("cancel")).on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
                     .icon(icon::from_name("dialog-warning-symbolic").size(64))
@@ -1509,9 +1508,8 @@ impl Application for App {
                 }
                 let discard_button =
                     widget::button::destructive(fl!("discard")).on_press(Message::QuitForce);
-                let cancel_button = widget::button::standard(fl!("cancel"))
-                    .style(theme::Button::Link)
-                    .on_press(Message::DialogCancel);
+                let cancel_button = 
+                    widget::button::text(fl!("cancel")).on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
                     .icon(icon::from_name("dialog-warning-symbolic").size(64))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1466,8 +1466,9 @@ impl Application for App {
                     widget::button::suggested(fl!("save")).on_press(Message::Save(Some(*entity)));
                 let discard_button = widget::button::destructive(fl!("discard"))
                     .on_press(Message::TabCloseForce(*entity));
-                let cancel_button =
-                    widget::button::standard(fl!("cancel")).style(theme::Button::Link).on_press(Message::DialogCancel);
+                let cancel_button = widget::button::standard(fl!("cancel"))
+                    .style(theme::Button::Link)
+                    .on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
                     .icon(icon::from_name("dialog-warning-symbolic").size(64))
@@ -1508,8 +1509,9 @@ impl Application for App {
                 }
                 let discard_button =
                     widget::button::destructive(fl!("discard")).on_press(Message::QuitForce);
-                let cancel_button =
-                    widget::button::standard(fl!("cancel")).style(theme::Button::Link).on_press(Message::DialogCancel);
+                let cancel_button = widget::button::standard(fl!("cancel"))
+                    .style(theme::Button::Link)
+                    .on_press(Message::DialogCancel);
                 let dialog = widget::dialog(fl!("prompt-save-changes-title"))
                     .body(fl!("prompt-unsaved-changes"))
                     .icon(icon::from_name("dialog-warning-symbolic").size(64))


### PR DESCRIPTION
Closes #197.

`widget::button::text` achieves a similar result (potentially slightly better since it has a highlight when hovering over), but doesn't use the accent color.
Edit: switched it to `widget::button::text`, since it will use the accent color after libcosmic is updated for `cosmic-edit`.