### PR TITLE
support CARGO_TARGET_DIR

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,7 +8,8 @@ base-dir := absolute_path(clean(rootdir / prefix))
 
 export INSTALL_DIR := base-dir / 'share'
 
-bin-src := 'target' / 'release' / name
+cargo-target-dir := env('CARGO_TARGET_DIR', 'target')
+bin-src := cargo-target-dir / 'release' / name
 bin-dst := base-dir / 'bin' / name
 
 desktop := APPID + '.desktop'


### PR DESCRIPTION
Previously failed to build from source when CARGO_TARGET_DIR is set, because the justfile assumed the target dir was './target'.