### PR TITLE
i18n: Update Slovak translation

### DIFF
--- a/i18n/sk/cosmic_edit.ftl
+++ b/i18n/sk/cosmic_edit.ftl
@@ -32,7 +32,7 @@ prompt-save-changes-title = Neuložené zmeny
 prompt-unsaved-changes = Máte neuložené zmeny. Uložiť?
 cancel = Zrušiť
 discard = Zahodiť zmeny
-save-all = Zobraziť všetko
+save-all = Uložiť všetko
 
 ## Settings
 settings = Nastavenia
@@ -61,6 +61,7 @@ replace = Nahradiť
 replace-all = Nahradiť všetko
 case-sensitive = Rozlišovanie veľkosti písmen
 use-regex = Použiť regex
+wrap-around = Pokračovať od začiatku
 
 # Menu
 


### PR DESCRIPTION
- Update for wrap-around.
- I made mistake in previous update. Instead of 'save all' I did 'show all'. This should be fixed here.