### PR TITLE
Fix clicking directories in nav bar in condensed mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1472,6 +1472,11 @@ impl Application for App {
                                 }
                             }
                         }
+
+                        // Prevent nav bar from closing when selecting a
+                        // folder in condensed mode.
+                        self.core_mut().nav_bar_set_toggled(true);
+
                         Command::none()
                     }
                     ProjectNode::File { path, .. } => {


### PR DESCRIPTION
This fixes the issue where the nav bar would close when clicking a directory in the nav bar when the window width was reduced to a size where only the nav bar was visible.

Fixes #85