### PR TITLE
feat: improve text search

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -219,7 +219,10 @@ impl EditorTab {
                 regex
                     .find_iter(buffer.lines[cursor.line].text())
                     .filter_map(|m| {
-                        if cursor.line != start_line || m.start() >= cursor.index {
+                        if cursor.line != start_line
+                            || m.start() >= cursor.index
+                            || m.start() < cursor.index && wrapped == true
+                        {
                             Some((m.start(), m.len()))
                         } else {
                             None
@@ -263,6 +266,7 @@ impl EditorTab {
         let mut cursor = editor.cursor();
         let mut wrapped = false; // Keeps track of whether the search has wrapped around yet.
         let start_line = cursor.line;
+        let current_selection = editor.selection();
 
         if forwards {
             while cursor.line < editor.with_buffer(|buffer| buffer.lines.len()) {
@@ -270,7 +274,11 @@ impl EditorTab {
                     regex
                         .find_iter(buffer.lines[cursor.line].text())
                         .filter_map(|m| {
-                            if cursor.line != start_line || m.start() > cursor.index {
+                            if cursor.line != start_line
+                                || m.start() > cursor.index
+                                || m.start() == cursor.index && current_selection == Selection::None
+                                || m.start() < cursor.index && wrapped == true
+                            {
                                 Some((m.start(), m.end()))
                             } else {
                                 None
@@ -309,7 +317,11 @@ impl EditorTab {
                     regex
                         .find_iter(buffer.lines[cursor.line].text())
                         .filter_map(|m| {
-                            if cursor.line != start_line || m.start() < cursor.index {
+                            if cursor.line != start_line
+                                || m.start() < cursor.index
+                                || m.start() == cursor.index && current_selection == Selection::None
+                                || m.start() > cursor.index && wrapped == true
+                            {
                                 Some((m.start(), m.end()))
                             } else {
                                 None


### PR DESCRIPTION
This PR improves upon search feature and fixes a few bugs I've found while testing.

- searching while cursor is at the start of the matched word now works (e.g. |abc now highlights "|abc")
-   wrapping behavior now works on single-line files (e.g. abcabc| now highlights "|abc"abc)

This works for forward and backward searches, and also replace