### PR TITLE
Fix clicking outside textbox to unfocus

### DIFF
--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1100,6 +1100,8 @@ where
                     }
 
                     status = Status::Captured;
+                } else {
+                    state.is_focused = false;
                 }
             }
             Event::Mouse(MouseEvent::ButtonReleased(Button::Left)) => {


### PR DESCRIPTION
This PR fixes a bug where text_box doesn't unfocus when clicking the Find menu (#185). Also probably fixes #172 