### PR TITLE
Enable saving read-only/root files via pkexec (Fixes #249)

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -170,6 +170,8 @@ impl EditorTab {
                             .arg("tee")
                             .arg(path)
                             .stdin(Stdio::piped())
+                            .stdout(Stdio::null()) // Redirect stdout to /dev/null
+                            .stderr(Stdio::inherit()) // Retain stderr for error visibility
                             .spawn()
                         {
                             if let Some(mut stdin) = output.stdin.take() {

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -147,49 +147,65 @@ impl EditorTab {
     }
 
     pub fn save(&mut self) {
-        if let Some(path) = &self.path_opt {
-            let mut editor = self.editor.lock().unwrap();
-            let mut text = String::new();
-            editor.with_buffer(|buffer| {
-                for line in buffer.lines.iter() {
-                    text.push_str(line.text());
-                    text.push_str(line.ending().as_str());
-                }
-            });
-            match fs::write(path, &text) {
-                Ok(()) => {
-                    editor.save_point();
-                    log::info!("saved {:?}", path);
-                }
-                Err(err) => {
-                    if err.kind() == std::io::ErrorKind::PermissionDenied {
-                        log::warn!("Permission denied. Attempting to save with pkexec.");
+    if let Some(path) = &self.path_opt {
+        let mut editor = self.editor.lock().unwrap();
+        let mut text = String::new();
+        
+        editor.with_buffer(|buffer| {
+            for line in buffer.lines.iter() {
+                text.push_str(line.text());
+                text.push_str(line.ending().as_str());
+            }
+        });
 
-                        // Start the `pkexec tee` process
-                        if let Ok(mut output) = Command::new("pkexec")
-                            .arg("tee")
-                            .arg(path)
-                            .stdin(Stdio::piped())
-                            .stdout(Stdio::null()) // Redirect stdout to /dev/null
-                            .stderr(Stdio::inherit()) // Retain stderr for error visibility
-                            .spawn()
-                        {
-                            if let Some(mut stdin) = output.stdin.take() {
-                                if let Err(e) = stdin.write_all(text.as_bytes()) {
-                                    // Log the error but do not crash
-                                    log::error!("Failed to write to stdin: {}", e);
-                                }
-                            } else {
-                                log::error!("Failed to access stdin of pkexec process.");
+        match fs::write(path, &text) {
+            Ok(()) => {
+                editor.save_point();
+                log::info!("saved {:?}", path);
+            }
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::PermissionDenied {
+                    log::warn!("Permission denied. Attempting to save with pkexec.");
+
+                    if let Ok(mut output) = Command::new("pkexec")
+                        .arg("tee")
+                        .arg(path)
+                        .stdin(Stdio::piped())
+                        .stdout(Stdio::null()) // Redirect stdout to /dev/null
+                        .stderr(Stdio::inherit()) // Retain stderr for error visibility
+                        .spawn()
+                    {
+                        if let Some(mut stdin) = output.stdin.take() {
+                            if let Err(e) = stdin.write_all(text.as_bytes()) {
+                                log::error!("Failed to write to stdin: {}", e);
                             }
                         } else {
-                            log::error!("Failed to spawn pkexec process. Check permissions or path.");
+                            log::error!("Failed to access stdin of pkexec process.");
                         }
+
+                        // Ensure the child process is reaped
+                        match output.wait() {
+                            Ok(status) => {
+                                if status.success() {
+                                    // Mark the editor's state as saved if the process succeeds
+                                    editor.save_point();
+                                    log::info!("File saved successfully with pkexec.");
+                                } else {
+                                    log::error!("pkexec process exited with a non-zero status: {:?}", status);
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("Failed to wait on pkexec process: {}", e);
+                            }
+                        }
+                    } else {
+                        log::error!("Failed to spawn pkexec process. Check permissions or path.");
                     }
                 }
             }
-        } else {
-            log::warn!("tab has no path yet");
+        }
+    } else {
+        log::warn!("tab has no path yet");
         }
     }
 

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -168,7 +168,7 @@ impl EditorTab {
                         // Start the `pkexec tee` process
                         let mut output = Command::new("pkexec")
                             .arg("tee")
-                            .arg(path.to_str().unwrap())
+                            .arg(path)
                             .stdin(Stdio::piped())
                             .spawn()
                             .expect("Failed to spawn pkexec process");

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -175,13 +175,13 @@ impl EditorTab {
                             if let Some(mut stdin) = output.stdin.take() {
                                 if let Err(e) = stdin.write_all(text.as_bytes()) {
                                     // Log the error but do not crash
-                                    eprintln!("Failed to write to stdin: {}", e);
+                                    log::error!("Failed to write to stdin: {}", e);
                                 }
                             } else {
-                                eprintln!("Failed to access stdin of pkexec process.");
+                                log::error!("Failed to access stdin of pkexec process.");
                             }
                         } else {
-                            eprintln!("Failed to spawn pkexec process. Check permissions or path.");
+                            log::error!("Failed to spawn pkexec process. Check permissions or path.");
                         }
                     }
                 }


### PR DESCRIPTION
This Patch addresses the issue where users couldn't open Cosmic Edit as root. It allows users to save read-only or root files using pkexec for privilege escalation, all within the graphical interface of Cosmic Edit, eliminating the need to open the terminal.

Changes:

    Implemented pkexec functionality for saving read-only/root files.
    Added a confirmation dialog for file modifications.

This feature resolves issue #249 and streamlines the process, ensuring a smoother experience for users managing protected files directly within Cosmic Edit.