### PR TITLE
Patch: Use updated onig crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,8 +4456,7 @@ dependencies = [
 [[package]]
 name = "onig_sys"
 version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+source = "git+https://github.com/rust-onig/rust-onig.git?branch=main#c4378abcbf30d58cf5f230c0d2e6375f2be05a47"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7923,3 +7922,8 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[patch.unused]]
+name = "onig"
+version = "6.5.0"
+source = "git+https://github.com/rust-onig/rust-onig.git?branch=main#c4378abcbf30d58cf5f230c0d2e6375f2be05a47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ wgpu = ["libcosmic/wgpu", "cosmic-files/wgpu"]
 inherits = "release"
 debug = true
 
+[patch.crates-io]
+onig = { git = "https://github.com/rust-onig/rust-onig.git", branch = "main" }
+onig_sys = { git = "https://github.com/rust-onig/rust-onig.git", branch = "main" }
+
 # [patch.'https://github.com/pop-os/libcosmic']
 # libcosmic = { path = "../libcosmic" }
 # cosmic-config = { path = "../libcosmic/cosmic-config" }


### PR DESCRIPTION
This patch fixes building with GCC 15, as the bundled C oniguruma library had to be updated in rust-onig. The upstream rust-onig project haven't tagged a new release yet.