### PR TITLE
fix issue with trying to replace-all a regex that targets empty lines

### DIFF
--- a/src/tab.rs
+++ b/src/tab.rs
@@ -286,13 +286,26 @@ impl EditorTab {
                 end.index = index + len;
 
                 editor.start_change();
+                // if index = 0 and len = 0, we are targeting and deleting an empty line
+                // we'll move either cursor or end to delete the newline
+                if index == 0 && len == 0 {
+                    if cursor.line > 0 {
+                        // move the cursor up one line
+                        cursor.line -= 1;
+                        cursor.index =
+                            editor.with_buffer(|buffer| buffer.lines[cursor.line].text().len());
+                    } else if cursor.line + 1 < editor.with_buffer(|buffer| buffer.lines.len()) {
+                        // move the end down one line
+                        end.line += 1;
+                        end.index = 0;
+                    }
+                }
                 editor.delete_range(cursor, end);
                 cursor = editor.insert_at(cursor, replace, None);
                 editor.set_cursor(cursor);
                 // Need to disable selection to prevent the new cursor showing selection to old location
                 editor.set_selection(Selection::None);
                 editor.finish_change();
-
                 return true;
             }
 


### PR DESCRIPTION
fixes #342 

**changes tl;dr**
- most text editors let you replace empty lines by searching for the regex `^$`
- for cosmic-edit, this infinite loops since the start and end are always the same, with a zero-length replacement
- this copies the logic for delete/backspace to delete the empty lines

to test, have an editor with the following content:
```

w

ww
w
www
.
```

CTRL+R:
- find `^$`
- replace `<empty string>`
clicking replace all should give:
```
w
ww
w
www
.
```

further testing:
- find `^w$`
- replace `<empty string>`
clicking replace all should give:
```

ww

www
.
```
(because the search is non-zero, you're actually just targeting the `w` here)