### PR TITLE
bugfix(text_box): ignoring tab key presses when alt is held

### DIFF
--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -991,7 +991,7 @@ where
                     status = Status::Captured;
                 }
                 Named::Tab => {
-                    if !modifiers.control() {
+                    if !modifiers.control() && !modifiers.alt() {
                         if modifiers.shift() {
                             editor.action(Action::Unindent);
                         } else {


### PR DESCRIPTION
maybe fixes #298 - pending feedback

**changes tl;dr**
- ignore `Named::Tab` keyboard events when alt modifier is held

doesn't cause any difference in pop 24.04 cosmic, but might want to wait to see if it actually fixes the bug :D 