### PR TITLE
Refactor: Extract monospace_attrs() helper to eliminate code duplication

### DIFF
--- a/src/line_number.rs
+++ b/src/line_number.rs
@@ -1,5 +1,5 @@
 use cosmic_text::{
-    Align, Attrs, AttrsList, BufferLine, Family, FontSystem, LayoutLine, LineEnding, Shaping, Wrap,
+    Align, AttrsList, BufferLine, FontSystem, LayoutLine, LineEnding, Shaping, Wrap,
 };
 use std::collections::HashMap;
 
@@ -27,8 +27,7 @@ impl LineNumberCache {
 
     pub fn get(&mut self, font_system: &mut FontSystem, key: LineNumberKey) -> &Vec<LayoutLine> {
         self.cache.entry(key).or_insert_with(|| {
-            //TODO: do not repeat, used in App::init
-            let attrs = Attrs::new().family(Family::Monospace);
+            let attrs = crate::monospace_attrs();
             let text = format!("{:width$}", key.number, width = key.width);
             let mut buffer_line = BufferLine::new(
                 text,

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,12 @@ pub fn icon_cache_get(name: &'static str, size: u16) -> icon::Icon {
     icon_cache.get(name, size)
 }
 
+/// Creates monospace attributes for text rendering.
+/// This centralizes the creation of monospace font attributes to avoid duplication.
+pub fn monospace_attrs() -> cosmic_text::Attrs<'static> {
+    cosmic_text::Attrs::new().family(Family::Monospace)
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(unix, not(target_os = "redox")))]
     match fork::daemon(true, true) {
@@ -1298,8 +1304,7 @@ impl Application for App {
         let font_names = {
             let mut font_names = Vec::new();
             let mut font_system = font_system().write().unwrap();
-            //TODO: do not repeat, used in Tab::new
-            let attrs = cosmic_text::Attrs::new().family(Family::Monospace);
+            let attrs = monospace_attrs();
             for face in font_system.raw().db().faces() {
                 if attrs.matches(face) && face.monospaced {
                     //TODO: get localized name if possible

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -47,8 +47,7 @@ pub struct EditorTab {
 
 impl EditorTab {
     pub fn new(config: &Config) -> Self {
-        //TODO: do not repeat, used in App::init
-        let attrs = Attrs::new().family(cosmic_text::Family::Monospace);
+        let attrs = crate::monospace_attrs();
         let zoom_adj = Default::default();
         let mut buffer = Buffer::new_empty(config.metrics(zoom_adj));
         buffer.set_text(


### PR DESCRIPTION
- Add monospace_attrs() function in main.rs to centralize monospace font attributes creation
- Replace duplicated Attrs::new().family(Family::Monospace) calls in:
  * line_number.rs: LineNumberCache::get() method
  * main.rs: App::init() font enumeration
  * tab.rs: EditorTab::new() constructor
- Remove unused imports (Attrs, Family) from line_number.rs
- Resolves TODO comments about code repetition across modules

This change improves maintainability by having a single source of truth for monospace font configuration.