### PR TITLE
feat(ime): minimal IME support for the text_box widget

### DIFF
--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -7,6 +7,7 @@ use cosmic::{
         Border, Radians, Shell, Transformation,
         clipboard::Clipboard,
         image,
+        input_method::{Event as InputMethodEvent, InputMethod, Preedit, Purpose},
         keyboard::{Key, key::Named},
         layout::{self, Layout},
         renderer::{self, Quad, Renderer as _},
@@ -16,6 +17,7 @@ use cosmic::{
             operation::{self, Operation},
             tree,
         },
+        window::Event as WindowEvent,
     },
     iced::{
         Color, Element, Length, Padding, Point, Rectangle, Size, Vector,
@@ -126,6 +128,36 @@ where
     pub fn on_focus(mut self, on_focus: Message) -> Self {
         self.on_focus = Some(on_focus);
         self
+    }
+
+    fn input_method<'b>(
+        &self,
+        state: &'b State,
+        editor: &BorrowedWithFontSystem<'_, ViEditor<'static, 'static>>,
+        scale_factor: f32,
+        layout: Layout<'_>,
+    ) -> InputMethod<&'b str> {
+        if !state.is_focused {
+            return InputMethod::Disabled;
+        };
+
+        let editor_pos = layout.position() + [self.padding.left, self.padding.top].into();
+        let (caret_x, caret_y) = editor.cursor_position().unwrap_or_default();
+        InputMethod::Enabled {
+            cursor: Rectangle::new(
+                Point::new(
+                    editor_pos.x
+                        + (caret_x as f32 + state.editor_offset_x.get() as f32) / scale_factor,
+                    editor_pos.y + (caret_y as f32) / scale_factor,
+                ),
+                Size::new(
+                    1.0,
+                    (self.metrics.scale(scale_factor).line_height) / scale_factor,
+                ),
+            ),
+            purpose: Purpose::Normal,
+            preedit: state.preedit.as_ref().map(Preedit::as_ref),
+        }
     }
 }
 
@@ -1101,6 +1133,33 @@ where
                 }
                 state.modifiers = *modifiers;
             }
+            Event::InputMethod(event) => match event {
+                InputMethodEvent::Opened | InputMethodEvent::Closed => {
+                    let metrics = self.metrics.scale(scale_factor);
+                    state.preedit = matches!(event, InputMethodEvent::Opened).then(|| {
+                        let mut preedit = Preedit::new();
+                        preedit.text_size = Some(metrics.font_size.into());
+                        preedit
+                    });
+                }
+                InputMethodEvent::Preedit(content, selection) => {
+                    if state.is_focused {
+                        state.preedit = Some(Preedit {
+                            content: content.to_owned(),
+                            selection: selection.clone(),
+                            text_size: Some(self.metrics.font_size.into()),
+                        });
+                    }
+                }
+                InputMethodEvent::Commit(text) => {
+                    if state.is_focused {
+                        editor.start_change();
+                        editor.insert_string(&text, None);
+                        editor.finish_change();
+                        shell.capture_event();
+                    }
+                }
+            },
             Event::Mouse(MouseEvent::ButtonPressed(button)) => {
                 if let Some(p) = cursor_position.position_in(layout.bounds()) {
                     state.is_focused = true;
@@ -1336,6 +1395,14 @@ where
                     shell.capture_event();
                 }
             }
+            Event::Window(WindowEvent::RedrawRequested(_now)) => {
+                shell.request_input_method(&self.input_method(
+                    state,
+                    &editor,
+                    scale_factor,
+                    layout,
+                ));
+            }
             _ => (),
         }
 
@@ -1385,6 +1452,7 @@ pub struct State {
     scrollbar_h_rect: Cell<Option<Rectangle<f32>>>,
     handle_opt: Mutex<Option<image::Handle>>,
     shift_anchor: Mutex<Option<Cursor>>,
+    preedit: Option<Preedit>,
 }
 
 impl State {
@@ -1402,6 +1470,7 @@ impl State {
             scrollbar_h_rect: Cell::new(None),
             handle_opt: Mutex::new(None),
             shift_anchor: Mutex::new(None),
+            preedit: None,
         }
     }
 }

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1397,8 +1397,8 @@ where
             Event::Window(WindowEvent::RedrawRequested(_now)) => {
                 if state.is_focused {
                     state.caret_position = editor.cursor_position().unwrap_or(state.caret_position);
+                    shell.request_input_method(&self.input_method(state, scale_factor, layout));
                 }
-                shell.request_input_method(&self.input_method(state, scale_factor, layout));
             }
             _ => (),
         }

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -133,7 +133,6 @@ where
     fn input_method<'b>(
         &self,
         state: &'b State,
-        editor: &BorrowedWithFontSystem<'_, ViEditor<'static, 'static>>,
         scale_factor: f32,
         layout: Layout<'_>,
     ) -> InputMethod<&'b str> {
@@ -142,7 +141,7 @@ where
         };
 
         let editor_pos = layout.position() + [self.padding.left, self.padding.top].into();
-        let (caret_x, caret_y) = editor.cursor_position().unwrap_or_default();
+        let (caret_x, caret_y) = state.caret_position;
         InputMethod::Enabled {
             cursor: Rectangle::new(
                 Point::new(
@@ -1396,12 +1395,10 @@ where
                 }
             }
             Event::Window(WindowEvent::RedrawRequested(_now)) => {
-                shell.request_input_method(&self.input_method(
-                    state,
-                    &editor,
-                    scale_factor,
-                    layout,
-                ));
+                if state.is_focused {
+                    state.caret_position = editor.cursor_position().unwrap_or(state.caret_position);
+                }
+                shell.request_input_method(&self.input_method(state, scale_factor, layout));
             }
             _ => (),
         }
@@ -1452,6 +1449,7 @@ pub struct State {
     scrollbar_h_rect: Cell<Option<Rectangle<f32>>>,
     handle_opt: Mutex<Option<image::Handle>>,
     shift_anchor: Mutex<Option<Cursor>>,
+    caret_position: (i32, i32),
     preedit: Option<Preedit>,
 }
 
@@ -1470,6 +1468,7 @@ impl State {
             scrollbar_h_rect: Cell::new(None),
             handle_opt: Mutex::new(None),
             shift_anchor: Mutex::new(None),
+            caret_position: (0, 0),
             preedit: None,
         }
     }


### PR DESCRIPTION
Fix the `cosmic-edit` specific part of https://github.com/pop-os/cosmic-epoch/issues/2174.

The input method support in iced 14.0 requires text widgets to implement some logic to support input method input.

This PR includes this for the `cosmic-edit` specific text widgets in `text_box.rs`.

https://github.com/user-attachments/assets/7887ec4b-07ba-40eb-b103-3f735c80c3f1

FYI, my old PR of backporting the IME feature may be a good reference to add IME support for an existing custom text widget. See `text_editor.rs`:
- https://github.com/pop-os/iced/pull/255/changes#diff-f50c40e421b597328bff5e029fc5734fe37f7a9b084ba39699a95cac1ab107b7

---

For text components other than `text_box`, the following PRs will add IME support:
- https://github.com/pop-os/libcosmic/pull/1182
- Bug fix for the find and replace feature:
  - https://github.com/pop-os/libcosmic/pull/1222

(I will force-push this branch to update my fork to rebase to newer upstream rev)

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
