### PR TITLE
Close application upon closing last tab

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2771,9 +2771,9 @@ impl Application for App {
                 self.tab_model.remove(entity);
                 self.update_watcher();
 
-                // If that was the last tab, make a new empty one
+                // If that was the last tab, exit the application
                 if self.tab_model.iter().next().is_none() {
-                    self.open_tab(None);
+                    return self.update(Message::QuitForce)
                 }
 
                 // Close PromptSaveClose dialog if open for this entity


### PR DESCRIPTION
fixes #544 

Exit the application when the last tab is closed instead of creating a new tab.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

