### PR TITLE
find panel fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2052,6 +2052,9 @@ impl Application for App {
                         has_focus,
                     };
                 }
+                if !has_focus {
+                    return self.update_focus();
+                }
             }
             Message::GitProjectStatus(project_status) => {
                 self.git_project_status = Some(project_status);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -104,7 +104,12 @@ fn format_recent_menu_path(path: &PathBuf, home_dir_opt: Option<&PathBuf>) -> St
             continue;
         }
 
-        return format!("{}{}{}", take_prefix_chars(&display, prefix_len), ELLIPSIS, tail);
+        return format!(
+            "{}{}{}",
+            take_prefix_chars(&display, prefix_len),
+            ELLIPSIS,
+            tail
+        );
     }
 
     truncate_middle(&display, RECENT_MENU_LABEL_MAX_CHARS)

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1414,8 +1414,10 @@ impl operation::Focusable for State {
     }
 
     fn focus(&mut self) {
+        if !self.is_focused {
+            self.emit_focus = true;
+        }
         self.is_focused = true;
-        self.emit_focus = true;
     }
 
     fn unfocus(&mut self) {

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -744,7 +744,6 @@ where
 
         // Draw vertical scrollbar
         if let Some(scrollbar_v_rect) = state.scrollbar_v_rect.get() {
-
             // neutral_3, 0.7
             let track_color = cosmic_theme
                 .palette

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1226,7 +1226,9 @@ where
             }
             Event::Mouse(MouseEvent::ButtonReleased(Button::Left)) => {
                 state.dragging = None;
-                shell.capture_event();
+                if cursor_position.position_in(layout.bounds()).is_some() {
+                    shell.capture_event();
+                }
                 if let Some(on_auto_scroll) = &self.on_auto_scroll {
                     shell.publish(on_auto_scroll(None));
                 }


### PR DESCRIPTION

- Mouse input is not processed on the find panel, so if you open it you can't close it with the mouse. Also text selection using mouse is also weird. It selects the main text and if you hover over the find textinput it selects that too.
- If find panel is open when you click on the main text area, find text input still has some amount of focus! for example you can click and type in the main text area, but ctrl+z doesn't work until you close the find panel.

https://github.com/user-attachments/assets/883fa002-8512-4680-828f-3490fcad3c13

Not 100% my fix for the focus is correct since it created an infinite focus loop that I had to then fix again. @wash2 may know a better fix.
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

