### PR TITLE
fix: allow editor focus when project search drawer is open

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -480,6 +480,7 @@ pub struct App {
     project_search_id: widget::Id,
     project_search_value: String,
     project_search_result: Option<ProjectSearchResult>,
+    project_search_has_focus: bool,
     watcher_opt: Option<(
         notify::RecommendedWatcher,
         HashSet<(PathBuf, RecursiveMode)>,
@@ -792,7 +793,7 @@ impl App {
     fn update_focus(&self) -> Task<Message> {
         if self.core.window.show_context {
             match self.context_page {
-                ContextPage::ProjectSearch => {
+                ContextPage::ProjectSearch if self.project_search_has_focus => {
                     widget::text_input::focus(self.project_search_id.clone())
                 }
                 _ => Task::none(),
@@ -1495,6 +1496,7 @@ impl Application for App {
             project_search_id: widget::Id::unique(),
             project_search_value: String::new(),
             project_search_result: None,
+            project_search_has_focus: false,
             watcher_opt: None,
             modifiers: Modifiers::empty(),
         };
@@ -2053,6 +2055,7 @@ impl Application for App {
                     };
                 }
                 if !has_focus {
+                    self.project_search_has_focus = false;
                     return self.update_focus();
                 }
             }
@@ -2440,6 +2443,7 @@ impl Application for App {
                 };
 
                 if let Some((path, cursor)) = path_cursor_opt {
+                    self.project_search_has_focus = false;
                     if let Some(entity) = self.open_tab(Some(path)) {
                         return Task::batch([
                             //TODO: why must this be done in a command?
@@ -2502,6 +2506,7 @@ impl Application for App {
             }
             Message::ProjectSearchResult(project_search_result) => {
                 self.project_search_result = Some(project_search_result);
+                self.project_search_has_focus = true;
 
                 // Focus correct input
                 return self.update_focus();
@@ -2537,6 +2542,7 @@ impl Application for App {
                 }
             }
             Message::ProjectSearchValue(value) => {
+                self.project_search_has_focus = true;
                 self.project_search_value = value;
             }
             Message::PromptSaveChanges(entity) => {
@@ -2853,6 +2859,9 @@ impl Application for App {
                     self.context_page = context_page;
                     self.core.window.show_context = true;
                 }
+
+                self.project_search_has_focus = self.core.window.show_context
+                    && self.context_page == ContextPage::ProjectSearch;
 
                 // Execute commands for specific pages
                 if self.core.window.show_context && self.context_page == ContextPage::GitManagement


### PR DESCRIPTION
  Focus gets stuck on the project search input when using "Find in project".
  After clicking a search result or clicking the editor text area, typing
  still goes to the search box instead of the editor.

  The root cause is `update_focus()` unconditionally focusing the project
  search input whenever the context drawer is open on the ProjectSearch page.
  Unlike the Find bar which has a `has_focus` flag to allow focus to return
  to the editor, the project search had no equivalent mechanism.

  This adds a `project_search_has_focus` flag mirroring the existing Find bar
  pattern:
  - Set `true` when opening the search drawer, typing in the search input,
    or receiving search results
  - Set `false` when clicking a search result or clicking the editor
  - `update_focus()` only focuses the search input when the flag is `true`

  Steps to reproduce (before fix):
  1. Open a project
  2. Edit -> Find in project...
  3. Search for something
  4. Click a result
  5. Click in the editor text area
  6. Start typing — input goes to the search box instead of the editor

  - [x] I have disclosed use of any AI generated code in my commit messages.
  - [x] I understand these changes in full and will be able to respond to review comments.
  - [x] My change is accurately described in the commit message.
  - [x] My contribution is tested and working as described.
  - [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.