### PR TITLE
fix(input): add support for non-latin keyboard layouts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ pub enum Message {
     GitProjectStatus(Vec<(String, PathBuf, Vec<GitStatus>)>),
     GitStage(PathBuf, PathBuf),
     GitUnstage(PathBuf, PathBuf),
-    Key(Modifiers, keyboard::Key),
+    Key(Modifiers, keyboard::Key, keyboard::key::Physical),
     LaunchUrl(String),
     Modifiers(Modifiers),
     NewFile,
@@ -2124,9 +2124,15 @@ impl Application for App {
                     |x| x,
                 );
             }
-            Message::Key(modifiers, key) => {
+            Message::Key(modifiers, key, physical_key) => {
+                let latin_key = match key.to_latin(physical_key) {
+                    Some(char) => keyboard::Key::Character(char.to_string().into()),
+                    None => key.clone(),
+                };
+
                 for (key_bind, action) in self.key_binds.iter() {
-                    if key_bind.matches(modifiers, &key) {
+                    if key_bind.matches(modifiers, &latin_key) || key_bind.matches(modifiers, &key)
+                    {
                         return self.update(action.message(None));
                     }
                 }
@@ -2779,7 +2785,7 @@ impl Application for App {
 
                 // If that was the last tab, exit the application
                 if self.tab_model.iter().next().is_none() {
-                    return self.update(Message::QuitForce)
+                    return self.update(Message::QuitForce);
                 }
 
                 // Close PromptSaveClose dialog if open for this entity
@@ -3307,12 +3313,15 @@ impl Application for App {
 
         let mut subscriptions = vec![
             event::listen_with(|event, status, window_id| match event {
-                event::Event::Keyboard(keyboard::Event::KeyPressed { modifiers, key, .. }) => {
-                    match status {
-                        event::Status::Ignored => Some(Message::Key(modifiers, key)),
-                        event::Status::Captured => None,
-                    }
-                }
+                event::Event::Keyboard(keyboard::Event::KeyPressed {
+                    modifiers,
+                    key,
+                    physical_key,
+                    ..
+                }) => match status {
+                    event::Status::Ignored => Some(Message::Key(modifiers, key, physical_key)),
+                    event::Status::Captured => None,
+                },
                 event::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
                     Some(Message::Modifiers(modifiers))
                 }


### PR DESCRIPTION
Part of pop-os/cosmic-epoch#3557. fixed an annoying bug where the shortcuts were ignored because it didn't match the physical key.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

