### PR TITLE
Fix missing  non-latin characters inserted via Rustdesk

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -26,6 +26,9 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Ctrl], Key::Character("f".into()), Find);
     bind!([Ctrl], Key::Character("h".into()), FindAndReplace);
     bind!([Ctrl], Key::Character("v".into()), Paste);
+    bind!([Shift], Key::Named(Named::Insert), Paste);
+    bind!([Ctrl], Key::Named(Named::Insert), Copy);
+    bind!([Shift], Key::Named(Named::Delete), Cut);
     bind!([Ctrl], Key::Character("t".into()), NewFile);
     bind!([Ctrl], Key::Character("n".into()), NewWindow);
     bind!([Ctrl], Key::Character("o".into()), OpenFileDialog);


### PR DESCRIPTION
This fixes a bug I noticed with Rustdesk. More details here: https://github.com/pop-os/iced/pull/356

Since cosmic-edit goes directly to cosmic-text, the changes in iced and libcosmic won't fix this issue. It has to be implemented in cosmic-edit too. Hence this pr.

____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

