### PR TITLE
Add `clear recent files/projects` and notify user if recent path can't be found

### DIFF
--- a/i18n/en/cosmic_edit.ftl
+++ b/i18n/en/cosmic_edit.ftl
@@ -88,6 +88,15 @@ encoding = Encoding...
 menu-git-management = Git management...
 print = Print
 quit = Quit
+clear-recent-files = Clear Recent Files
+clear-recent-projects = Clear Recent Projects
+recent-file-not-found = { $path } may have been moved or deleted. It has been removed from recent files.
+recent-project-not-found = { $path } may have been moved or deleted. It has been removed from recent projects.
+recent-paths-not-found-title = Missing Recents.
+try-again = Try Again
+missing-files = Files
+missing-projects = Projects
+
 
 ## Edit
 edit = Edit
@@ -100,6 +109,7 @@ select-all = Select all
 find = Find
 find-in-project = Find in project...
 spell-check = Spell check...
+ok = Ok
 
 ## View
 view = View
@@ -121,3 +131,4 @@ syntax-highlighting = Syntax highlighting...
 menu-settings = Settings...
 menu-keyboard-shortcuts = Keyboard shortcuts...
 menu-about = About COSMIC Text Editor...
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ pub enum RecentKind {
 pub enum Message {
     AppTheme(AppTheme),
     AutoScroll(Option<f32>),
-    CheckRecentFiles,
+    CheckRecentKind,
     Config(Config),
     ConfigState(ConfigState),
     ClearRecentFiles,
@@ -455,7 +455,7 @@ pub enum ContextPage {
 enum DialogPage {
     PromptSaveClose(segmented_button::Entity),
     PromptSaveQuit(Vec<segmented_button::Entity>),
-    PromptRecentFilesNotFound {
+    PromptRecentKindNotFound {
         files: Vec<PathBuf>,
         projects: Vec<PathBuf>,
     },
@@ -819,7 +819,7 @@ impl App {
                     self.dialog_page_opt = Some(DialogPage::PromptSaveQuit(unsaved));
                 }
             }
-            Some(DialogPage::PromptRecentFilesNotFound {..}) => {}
+            Some(DialogPage::PromptRecentKindNotFound {..}) => {}
             None => {}
         }
         Task::none()
@@ -1558,7 +1558,7 @@ impl Application for App {
         //TODO: try update_config here? It breaks loading system theme by default
         let command = Task::batch(vec![
             app.update_tab(),
-            Task::perform(async { cosmic::Action::App(Message::CheckRecentFiles) }, |x| x),
+            Task::perform(async { cosmic::Action::App(Message::CheckRecentKind) }, |x| x),
         ]);
         (app, command)
     }
@@ -1752,9 +1752,9 @@ impl Application for App {
 
                 Some(dialog.into())
             }
-            DialogPage::PromptRecentFilesNotFound { files, projects } => {
+            DialogPage::PromptRecentKindNotFound { files, projects } => {
                 let try_again_button = widget::button::text(fl!("try-again"))
-                    .on_press(Message::CheckRecentFiles);
+                    .on_press(Message::CheckRecentKind);
                 let ok_button = widget::button::suggested(fl!("ok"))
                     .on_press(Message::RemoveMissingRecents);
 
@@ -1848,7 +1848,7 @@ impl Application for App {
                     )
                 });
             }
-            Message::CheckRecentFiles => {
+            Message::CheckRecentKind => {
                 let missing_files: Vec<PathBuf> = self.config_state.recent_files
                     .iter()
                     .filter(|p| !p.exists())
@@ -1863,7 +1863,7 @@ impl Application for App {
                 if missing_files.is_empty() && missing_projects.is_empty() {
                     self.dialog_page_opt = None;
                 } else {
-                    self.dialog_page_opt = Some(DialogPage::PromptRecentFilesNotFound {
+                    self.dialog_page_opt = Some(DialogPage::PromptRecentKindNotFound {
                         files: missing_files,
                         projects: missing_projects,
                     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 pub enum Action {
     Todo,
     About,
+    ClearRecentFiles,
+    ClearRecentProjects,
     CloseFile,
     CloseProject(usize),
     Copy,
@@ -245,6 +247,8 @@ impl Action {
         match self {
             Self::Todo => Message::Todo,
             Self::About => Message::ToggleContextPage(ContextPage::About),
+            Self::ClearRecentFiles => Message::ClearRecentFiles,
+            Self::ClearRecentProjects => Message::ClearRecentProjects,
             Self::CloseFile => Message::CloseFile,
             Self::CloseProject(project_i) => Message::CloseProject(*project_i),
             Self::Copy => Message::Copy,
@@ -331,15 +335,25 @@ enum NewTab {
     Exists(Entity),
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecentKind {
+    File,
+    Project,
+}
+
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub enum Message {
     AppTheme(AppTheme),
     AutoScroll(Option<f32>),
+    CheckRecentFiles,
     Config(Config),
     ConfigState(ConfigState),
+    ClearRecentFiles,
+    ClearRecentProjects,
     CloseFile,
     CloseProject(usize),
+    CloseToast(widget::ToastId),
     CloseWindow(window::Id),
     Copy,
     Cut,
@@ -391,8 +405,10 @@ pub enum Message {
     PromptSaveChanges(segmented_button::Entity),
     Quit,
     QuitForce,
+    RecentKindNotFound(RecentKind, PathBuf),
     Redo,
     ReorderTab(ReorderEvent),
+    RemoveMissingRecents,
     RevertAllChanges,
     Save(Option<segmented_button::Entity>),
     SaveAll,
@@ -439,6 +455,10 @@ pub enum ContextPage {
 enum DialogPage {
     PromptSaveClose(segmented_button::Entity),
     PromptSaveQuit(Vec<segmented_button::Entity>),
+    PromptRecentFilesNotFound {
+        files: Vec<PathBuf>,
+        projects: Vec<PathBuf>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -486,6 +506,7 @@ pub struct App {
         HashSet<(PathBuf, RecursiveMode)>,
     )>,
     modifiers: Modifiers,
+    toasts: widget::Toasts<Message>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -710,6 +731,16 @@ impl App {
         self.save_config_state();
     }
 
+    fn clear_recent_files(&mut self) {
+        self.config_state.recent_files.clear();
+        self.save_config_state();
+    }
+
+    fn clear_recent_projects(&mut self) {
+        self.config_state.recent_projects.clear();
+        self.save_config_state();
+    }
+
     fn update_config(&mut self) -> Task<Message> {
         //TODO: provide iterator over data
         let entities: Vec<_> = self.tab_model.iter().collect();
@@ -788,6 +819,7 @@ impl App {
                     self.dialog_page_opt = Some(DialogPage::PromptSaveQuit(unsaved));
                 }
             }
+            Some(DialogPage::PromptRecentFilesNotFound {..}) => {}
             None => {}
         }
         Task::none()
@@ -848,7 +880,7 @@ impl App {
                 match expand_opt {
                     Some(id) => {
                         //TODO: can this be optimized?
-                        // Task not used becuase opening a folder just returns Task::none
+                        // Task not used because opening a folder just returns Task::none
                         let _ = self.on_nav_select(id);
                     }
                     None => {
@@ -1502,6 +1534,7 @@ impl Application for App {
             project_search_has_focus: false,
             watcher_opt: None,
             modifiers: Modifiers::empty(),
+            toasts: widget::Toasts::new(Message::CloseToast),
         };
 
         // Do not show nav bar by default. Will be opened by open_project if needed
@@ -1523,7 +1556,10 @@ impl Application for App {
         }
 
         //TODO: try update_config here? It breaks loading system theme by default
-        let command = app.update_tab();
+        let command = Task::batch(vec![
+            app.update_tab(),
+            Task::perform(async { cosmic::Action::App(Message::CheckRecentFiles) }, |x| x),
+        ]);
         (app, command)
     }
 
@@ -1716,6 +1752,62 @@ impl Application for App {
 
                 Some(dialog.into())
             }
+            DialogPage::PromptRecentFilesNotFound { files, projects } => {
+                let try_again_button = widget::button::text(fl!("try-again"))
+                    .on_press(Message::CheckRecentFiles);
+                let ok_button = widget::button::suggested(fl!("ok"))
+                    .on_press(Message::RemoveMissingRecents);
+
+                let mut content = widget::column::with_capacity(
+                    files.len() + projects.len() + 4
+                ).spacing(space_xxs);
+
+                if !files.is_empty() {
+                    content = content.push(widget::text::heading(fl!("missing-files")));
+                    for path in files {
+                        content = content.push(
+                            widget::text(path.display().to_string())
+                        );
+                    }
+                }
+
+                if !projects.is_empty() {
+                    content = content.push(widget::text::heading(fl!("missing-projects")));
+                    for path in projects {
+                        content = content.push(
+                            widget::text(path.display().to_string())
+                        );
+                    }
+                }
+
+                let dialog = widget::dialog()
+                    .title(fl!("recent-paths-not-found-title"))
+                    .icon(icon::from_name("dialog-warning-symbolic").size(64))
+                    .control(widget::container(
+                        widget::scrollable(content)
+                            .height(Length::Fixed(150.0))
+                            .width(Length::Fill)
+                    )
+                        .padding(8)
+                        .style(|theme| {
+                            let cosmic = theme.cosmic();
+                            widget::container::Style {
+                                background: Some(cosmic::iced::Background::Color(
+                                    cosmic::iced::Color::WHITE
+                                )),
+                                border: cosmic::iced::Border {
+                                    color: cosmic.accent_color().into(),
+                                    width: 1.0,
+                                    radius: cosmic.corner_radii.radius_s.into(),
+                                },
+                                ..Default::default()
+                            }
+                        }))
+                    .primary_action(ok_button)
+                    .secondary_action(try_again_button);
+
+                Some(dialog.into())
+            }
         }
     }
 
@@ -1756,6 +1848,27 @@ impl Application for App {
                     )
                 });
             }
+            Message::CheckRecentFiles => {
+                let missing_files: Vec<PathBuf> = self.config_state.recent_files
+                    .iter()
+                    .filter(|p| !p.exists())
+                    .cloned()
+                    .collect();
+                let missing_projects: Vec<PathBuf> = self.config_state.recent_projects
+                    .iter()
+                    .filter(|p| !p.exists())
+                    .cloned()
+                    .collect();
+
+                if missing_files.is_empty() && missing_projects.is_empty() {
+                    self.dialog_page_opt = None;
+                } else {
+                    self.dialog_page_opt = Some(DialogPage::PromptRecentFilesNotFound {
+                        files: missing_files,
+                        projects: missing_projects,
+                    });
+                }
+            }
             Message::Config(config) => {
                 if config != self.config {
                     log::info!("update config");
@@ -1769,6 +1882,14 @@ impl Application for App {
                     log::info!("update config state");
                     self.config_state = config_state;
                 }
+            }
+            Message::ClearRecentFiles => {
+                log::info!("clear recent files");
+                self.clear_recent_files();
+            }
+            Message::ClearRecentProjects => {
+                log::info!("clear recent projects");
+                self.clear_recent_projects();
             }
             Message::CloseFile => {
                 return self.update(Message::TabClose(self.tab_model.active()));
@@ -1806,6 +1927,9 @@ impl Application for App {
                     }
                     self.update_nav_bar_placeholder();
                 }
+            }
+            Message::CloseToast(toast_id) => {
+                self.toasts.remove(toast_id)
             }
             Message::CloseWindow(window_id) => {
                 if Some(window_id) == self.core.main_window_id() {
@@ -2410,15 +2534,26 @@ impl Application for App {
                     }
                 }
             }
+
+            // TODO: With the creation of `RecentKind` could we consider merging these into one
             Message::OpenRecentFile(index) => {
                 if let Some(path) = self.config_state.recent_files.get(index).cloned() {
-                    self.open_tab(Some(path));
-                    return self.update_tab();
+                    if path.exists() {
+                        self.open_tab(Some(path));
+                        return self.update_tab();
+                    } else {
+                        return self.update(Message::RecentKindNotFound(RecentKind::File, path));
+                    }
+
                 }
             }
             Message::OpenRecentProject(index) => {
                 if let Some(path) = self.config_state.recent_projects.get(index).cloned() {
-                    self.open_project(path);
+                    if path.exists() {
+                       self.open_project(path)
+                    } else {
+                        return self.update(Message::RecentKindNotFound(RecentKind::Project, path));
+                    }
                 }
             }
             Message::OpenSearchResult(file_i, line_i) => {
@@ -2560,6 +2695,22 @@ impl Application for App {
             Message::QuitForce => {
                 process::exit(0);
             }
+            Message::RecentKindNotFound(kind, path) => {
+                let msg = match kind {
+                    RecentKind::File => {
+                        self.config_state.recent_files.retain(|x| x != &path);
+                        fl!("recent-file-not-found",
+                            path = path.display().to_string())
+                    },
+                    RecentKind::Project => {
+                        self.config_state.recent_projects.retain(|x| x != &path);
+                        fl!("recent-project-not-found",
+                            path = path.display().to_string())
+                    }
+                };
+                self.save_config_state();
+                return self.toasts.push(widget::Toast::new(msg)).map(cosmic::Action::App)
+            }
             Message::Redo => {
                 if let Some(Tab::Editor(tab)) = self.active_tab() {
                     {
@@ -2569,6 +2720,12 @@ impl Application for App {
 
                     return self.update(Message::TabChanged(self.tab_model.active()));
                 }
+            }
+            Message::RemoveMissingRecents => {
+                self.config_state.recent_files.retain(|p| p.exists());
+                self.config_state.recent_projects.retain(|p| p.exists());
+                self.save_config_state();
+                self.dialog_page_opt = None;
             }
             Message::ReorderTab(ReorderEvent {
                 dragged,
@@ -3311,7 +3468,7 @@ impl Application for App {
 
         // Uncomment to debug layout:
         //content.explain(cosmic::iced::Color::WHITE)
-        content
+        widget::toaster(&self.toasts, content)
     }
 
     fn view_window(&self, window_id: window::Id) -> Element<'_, Message> {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -208,12 +208,30 @@ pub fn menu_bar<'a>(
         ));
     }
 
+    if !recent_files.is_empty() {
+        recent_files.push(MenuItem::Divider);
+        recent_files.push(MenuItem::Button(
+            fl!("clear-recent-files"),
+            None,
+            Action::ClearRecentFiles,
+        ));
+    }
+
     let mut recent_projects = Vec::with_capacity(config_state.recent_projects.len());
     for (i, path) in config_state.recent_projects.iter().enumerate() {
         recent_projects.push(MenuItem::Button(
             format_recent_menu_path(path, home_dir_opt.as_ref()),
             None,
             Action::OpenRecentProject(i),
+        ));
+    }
+
+    if !recent_projects.is_empty() {
+        recent_projects.push(MenuItem::Divider);
+        recent_projects.push(MenuItem::Button(
+            fl!("clear-recent-projects"),
+            None,
+            Action::ClearRecentProjects,
         ));
     }
 


### PR DESCRIPTION
* Added 'Clear Recent Files' and 'Clear Recent Projects' menu entries at the bottom of their sub-menus which only appear when the list is non-empty. The entries are separated by a divider. See Feature Request #531.
* Added silent removal with toast notification when a user clicks on a File or Project whose path is no longer valid. See Issue #586 
* Added a start up scan that `cosmic-edit` performs to validate the existence of every recent. If any path is no longer valid a dialog box will pop up listing them by their category "Files" or "Projects". The dialog box prompts two options; `Try Again` which on click will rescan the recents and will repeat the process if any are not found, or 'Ok' which removes the paths from their respective recents. 

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

