### PR TITLE
Fix tab auto focus on TabCloseForce

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2787,7 +2787,9 @@ impl Application for App {
             }
             Message::TabCloseForce(entity) => {
                 // Activate closest item
-                if let Some(position) = self.tab_model.position(entity) {
+                if self.tab_model.active() == entity
+                    && let Some(position) = self.tab_model.position(entity)
+                {
                     if position > 0 {
                         self.tab_model.activate_position(position - 1);
                     } else {


### PR DESCRIPTION
Auto focus should only trigger if the current tab is selected or else closing an unfocused tab would move the focused tab.

See: pop-os/cosmic-files#1949

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

