### PR TITLE
Better efficiency (fewer redraws) and context menu in input fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "build_helpers"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "cfg_aliases",
 ]
@@ -1350,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "almost",
  "configparser",
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "build_helpers",
  "dnd",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "bitflags 2.13.1",
  "build_helpers",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "futures",
  "iced_core",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "build_helpers",
  "bytes",
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3330,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.13.1",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "build_helpers",
  "cosmic-client-toolkit",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "build_helpers",
  "cosmic-client-toolkit",
@@ -4461,7 +4461,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#0ca1b784c931c946517379795ce87328c6a902b8"
+source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
 dependencies = [
  "apply",
  "ashpd 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "build_helpers"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "cfg_aliases",
 ]
@@ -1350,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -1410,8 +1410,8 @@ dependencies = [
 
 [[package]]
 name = "cosmic-files"
-version = "1.4.0"
-source = "git+https://github.com/pop-os/cosmic-files.git#ebce599f3a9f8c367feaf29f04ebcc34f6400d13"
+version = "1.5.0"
+source = "git+https://github.com/pop-os/cosmic-files.git#6e210a3753c814118b9f8daf5a83cd53136f28d9"
 dependencies = [
  "anyhow",
  "atomic_float",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "almost",
  "configparser",
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "build_helpers",
  "dnd",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "bitflags 2.13.1",
  "build_helpers",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "futures",
  "iced_core",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "build_helpers",
  "bytes",
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3330,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.13.1",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "build_helpers",
  "cosmic-client-toolkit",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "build_helpers",
  "cosmic-client-toolkit",
@@ -4461,7 +4461,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#633e6ab83fa019a75f7c7c94c55d04dc5650bd7b"
+source = "git+https://github.com/pop-os/libcosmic.git#c1897c01aa8a25776ceadeddcb161bb59ccffd79"
 dependencies = [
  "apply",
  "ashpd 0.12.3",

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1089,11 +1089,13 @@ where
                 Named::Backspace => {
                     delete_modifiers(&mut editor, Motion::LeftWord, *modifiers);
                     editor.action(Action::Backspace);
+                    editor.set_redraw(true);
                     shell.capture_event();
                 }
                 Named::Delete => {
                     delete_modifiers(&mut editor, Motion::RightWord, *modifiers);
                     editor.action(Action::Delete);
+                    editor.set_redraw(true);
                     shell.capture_event();
                 }
                 Named::Tab => {
@@ -1411,6 +1413,10 @@ where
             {
                 shell.publish(on_changed.clone());
             }
+        }
+
+        if editor.redraw() {
+            shell.request_redraw();
         }
     }
 }


### PR DESCRIPTION
Depends on 
- [x] https://github.com/pop-os/iced/pull/377
- [x] https://github.com/pop-os/libcosmic/pull/1382
- [x] https://github.com/pop-os/libcosmic/pull/1387
- [x] https://github.com/pop-os/cosmic-files/pull/1815



This pulls the changes in Iced and libcosmic that removes "redraw on any message", which means moving the cursor doesn't automatically call a redraw, widgets need to ask for it. I have found all places that previously was working normally because we were redrawing almost unconditionally. But it is possible that a custom widget somewhere still isn't asking for a redraw explicitly when its state changes. So, for QA I'd keep an eye on that.

For example I found that moving the cursor to middle of a word and pressing delete doesn't redraw, because we only redraw if the cursor changes position. Or pressing ctrl+a and then backspace doesn't redraw for the same reason. Or double-click to select a text wasn't drawing the selection. I have fixed those, but just examples for the QA team to check.

Demo:

https://github.com/user-attachments/assets/5e5940a8-fd89-498a-8670-85d540fcaa72


___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

